### PR TITLE
Only release the GIL *after* calling Py_XXX

### DIFF
--- a/src/conversions.c
+++ b/src/conversions.c
@@ -24,7 +24,7 @@ static duk_ret_t python_function_caller(duk_context *ctx)
     DukContext *dctx;
     duk_idx_t nargs, i;
     static char buf1[200], buf2[1024];
-    int gil_acquired = 0, ret = 1, err_occured;
+    int gil_acquired = 0, ret = 1;
 
     dctx = DukContext_get(ctx);
     nargs = duk_get_top(ctx);
@@ -60,16 +60,7 @@ static duk_ret_t python_function_caller(duk_context *ctx)
     Py_DECREF(args);
 
     if (!result) {
-        err_occured = PyErr_Occurred() != NULL;
         get_repr(func, buf1, 200);
-        if (!err_occured) {
-            get_repr(func, buf1, 200);
-            if (gil_acquired) {
-                dctx->py_thread_state = PyEval_SaveThread();
-                gil_acquired = 0;
-            }
-            return duk_error(ctx, DUK_ERR_ERROR, "Function (%s) failed", buf1);
-        }
         PyErr_Fetch(&ptype, &pval, &tb);
         if (!get_repr(pval, buf2, 1024)) get_repr(ptype, buf2, 1024);
         Py_XDECREF(ptype); Py_XDECREF(pval); Py_XDECREF(tb);

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -63,23 +63,23 @@ static duk_ret_t python_function_caller(duk_context *ctx)
         err_occured = PyErr_Occurred() != NULL;
         get_repr(func, buf1, 200);
         if (!err_occured) {
+            get_repr(func, buf1, 200);
             if (gil_acquired) {
                 dctx->py_thread_state = PyEval_SaveThread();
                 gil_acquired = 0;
             }
-            get_repr(func, buf1, 200);
-            duk_error(ctx, DUK_ERR_ERROR, "Function (%s) failed", buf1);
+            return duk_error(ctx, DUK_ERR_ERROR, "Function (%s) failed", buf1);
         }
         PyErr_Fetch(&ptype, &pval, &tb);
         if (!get_repr(pval, buf2, 1024)) get_repr(ptype, buf2, 1024);
         Py_XDECREF(ptype); Py_XDECREF(pval); Py_XDECREF(tb);
         PyErr_Clear();  /* In case there was an error in get_repr() */
+        get_repr(func, buf1, 200);
         if (gil_acquired) {
             dctx->py_thread_state = PyEval_SaveThread();
             gil_acquired = 0;
         }
-        get_repr(func, buf1, 200);
-        duk_error(ctx, DUK_ERR_ERROR, "Function (%s) failed with error: %s", buf1, buf2);
+        return duk_error(ctx, DUK_ERR_ERROR, "Function (%s) failed with error: %s", buf1, buf2);
 
     }
     python_to_duk(ctx, result);

--- a/src/module.c
+++ b/src/module.c
@@ -64,8 +64,10 @@ __attribute__ ((visibility ("default")))
 #endif
 PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
+#define INITERROR return NULL
 PyInit_dukpy(void)
-#else 
+#else
+#define INITERROR return
 initdukpy(void)
 #endif
 {
@@ -75,51 +77,27 @@ initdukpy(void)
     DukUndefined_Type.ob_type = &PyType_Type;
 #endif
     if (PyType_Ready(&DukUndefined_Type) < 0)
-#if PY_MAJOR_VERSION >= 3
-        return NULL;
-#else
-        return;
-#endif
+        INITERROR;
 
     DukContext_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&DukContext_Type) < 0)
-#if PY_MAJOR_VERSION >= 3
-        return NULL;
-#else
-        return;
-#endif
+        INITERROR;
 
     DukObject_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&DukObject_Type) < 0)
-#if PY_MAJOR_VERSION >= 3
-        return NULL;
-#else
-        return;
-#endif
+        INITERROR;
 
     DukArray_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&DukArray_Type) < 0)
-#if PY_MAJOR_VERSION >= 3
-        return NULL;
-#else
-        return;
-#endif
+        INITERROR;
 
     DukFunction_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&DukFunction_Type) < 0)
-#if PY_MAJOR_VERSION >= 3
-        return NULL;
-#else
-        return;
-#endif
+        INITERROR;
 
     DukEnum_Type.tp_new = PyType_GenericNew;
     if (PyType_Ready(&DukEnum_Type) < 0)
-#if PY_MAJOR_VERSION >= 3
-        return NULL;
-#else
-        return;
-#endif
+        INITERROR;
 
 #if PY_MAJOR_VERSION >= 3
     mod = PyModule_Create(&moduledef);

--- a/tests.py
+++ b/tests.py
@@ -28,6 +28,21 @@ class ContextTests(unittest.TestCase):
     def test_eval_file(self):
         pass
 
+    def test_pyfunc_success(self):
+        self.g.foo = lambda x: 213 + x
+        result = self.ctx.eval('foo(3)')
+        self.assertEqual(result, 213 + 3)
+
+    def test_pyfunc_exception(self):
+        def throw_exception():
+            raise ValueError('failure!')
+
+        self.g.throw_exception = throw_exception
+        with self.assertRaises(JSError) as err_ctx:
+            self.ctx.eval('throw_exception()')
+        self.assertIn("ValueError('failure!'",
+            err_ctx.exception.args[0]['message'])
+
     def test_undefined(self):
         self.assertEqual(repr(undefined), 'undefined')
 


### PR DESCRIPTION
The previous version of the code released the GIL before calling get_repr, but that's not OK because get_repr calls into PyObject_Repr, uses `Py_EnterRecursiveCall(" while getting the repr of an
object")`, which requires the to be held.

Moving the 'get_repr' before releasing the GIL fixes this.

Also, add "return duk_error", so it is clear that duk_error will never return.

-------------------

This fixes the following segfault:

```
0  0x00007fffeee0ee00 in get_repr (value=value@entry=0x7fffef7707b8, buf=buf@entry=0x7fffeee5d0c0 <buf1> "", bufsz=bufsz@entry=200, value=<optimized out>, buf=<optimized out>, bufsz=<optimized out>) at src/conversions.c:5
1  0x00007fffeee3756f in python_function_caller (ctx=0x555555e5a4a0) at src/conversions.c:64
2  0x00007fffeee146ca in duk.handle_call_raw (thr=0x555555e5a4a0, idx_func=7, call_flags=8) at duk_js_call.c:2231
```