### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ cflags = []
 if not hasattr(sys, 'getwindowsversion'):
     cflags.append('-fvisibility=hidden')
 
-sources = glob.glob('src/*.c') + glob.glob('src/duktape/*.c')
+sources = sorted(glob.glob('src/*.c') + glob.glob('src/duktape/*.c'))
 version = '0.3'
 
 if __name__ == '__main__':


### PR DESCRIPTION
so that openSUSE's (and other people's) python-dukpy-kovidgoyal package builds in a reproducible way, in spite of indeterministic filesystem readdir order and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.